### PR TITLE
fix: remove HTTP fallback for websocket

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -202,7 +202,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # OpenAI API 키 (환경변수에서 로드)
-OPENAI_API_KEY = ''
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 
 # ChromaDB 설정
 CHROMA_DB_PATH = BASE_DIR / 'chroma_db'

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,18 +18,12 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from django.http import HttpResponse
-
-def websocket_info(request):
-    """WebSocket 경로에 대한 HTTP 요청 처리"""
-    return HttpResponse("WebSocket endpoint. Use ws:// or wss:// protocol.", content_type="text/plain")
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('core.urls', namespace='core')),
     path('account/', include('account.urls')),
     path('blog/', include('blog.urls', namespace='blog')),  # 블로그
-    path('ws/chat/', websocket_info, name='websocket_info'),  # WebSocket 경로에 대한 HTTP 처리
 ]
 
 # DEBUG 모드에서 미디어 파일 제공

--- a/core/tests/test_chat_consumer.py
+++ b/core/tests/test_chat_consumer.py
@@ -1,0 +1,24 @@
+import pytest
+from channels.testing import WebsocketCommunicator
+from config.asgi import application
+from unittest.mock import patch
+
+class DummyRAG:
+    def stream_chat(self, query, top_k=5):
+        def gen():
+            yield {'type': 'sources', 'sources': []}
+            yield {'type': 'token', 'text': 'hi'}
+            yield {'type': 'end'}
+        return gen()
+
+@pytest.mark.asyncio
+async def test_chat_consumer_stream():
+    with patch('core.consumers.RAGService', DummyRAG):
+        communicator = WebsocketCommunicator(application, '/ws/chat/')
+        connected, _ = await communicator.connect()
+        assert connected
+        await communicator.send_json_to({'action': 'chat', 'query': 'hello'})
+        assert await communicator.receive_json_from() == {'type': 'sources', 'sources': []}
+        assert await communicator.receive_json_from() == {'type': 'token', 'text': 'hi'}
+        assert await communicator.receive_json_from() == {'type': 'end'}
+        await communicator.disconnect()


### PR DESCRIPTION
## Summary
- drop HTTP view on `/ws/chat/` so daphne can route websocket connections directly to Channels
- add unit test covering basic ChatConsumer streaming

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'channels')*
- `pip install channels daphne` *(fails: Could not find a version that satisfies the requirement channels==4.1.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b5e8b56ef4832c8257ff8faed753df)